### PR TITLE
Make skeleton-mapper optional

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -14,7 +14,6 @@
         "php": "^8.1",
         "doctrine/collections": "^1.8",
         "doctrine/rst-parser": "^0.5.3",
-        "doctrine/skeleton-mapper": "^2.0",
         "erusev/parsedown": "^1.7",
         "symfony/filesystem": "^6.0",
         "symfony/finder": "^6.0",
@@ -25,6 +24,7 @@
     },
     "require-dev": {
         "doctrine/coding-standard": "^12.0",
+        "doctrine/skeleton-mapper": "^2.0",
         "phpstan/phpstan": "^1.9",
         "phpstan/phpstan-deprecation-rules": "^1.1",
         "phpstan/phpstan-phpunit": "^1.3",

--- a/composer.json
+++ b/composer.json
@@ -12,7 +12,7 @@
     ],
     "require": {
         "php": "^8.1",
-        "doctrine/collections": "^1.8",
+        "doctrine/collections": "^1.8|^2.2",
         "doctrine/rst-parser": "^0.5.3",
         "erusev/parsedown": "^1.7",
         "symfony/filesystem": "^6.0",


### PR DESCRIPTION
This is a followup to https://github.com/doctrine/skeleton-mapper/pull/46, where skeleton-mapper is moved to the dev-dependencies of composer. It isn't actively used in the static-website-generator, but only in its tests.